### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ class ServerlessIntrospect {
               command: {
                 usage: 'Limit hooks to the ones provided by the provided command',
                 shortcut: 'c',
+                type: 'string',
                 customValidation: {
                   regularExpression: /^[a-z]+(:[a-z]+)*$/,
                   errorMessage: 'Commands should be provided in a:b:c format',


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessIntrospect for "command"
```